### PR TITLE
Setup Traefik docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+traefik/.env*

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -1,0 +1,63 @@
+version: '3.9'
+services:
+  traefik:
+    image: traefik:v2.9
+    container_name: srv_traefik
+    command:
+      ## Entrypoints
+      - --entryPoints.http.address=:80
+      - --entryPoints.https.address=:443
+      ## Logging
+      - --log=true
+      - --log.level=INFO
+      # - --accesslog=true
+      ## API
+      - --api=true
+      - --api.dashboard=true
+      # - --api.insecure=true
+      ## Providers
+      - --providers.docker=true
+      - --providers.docker.endpoint=unix:///var/run/docker.sock
+      - --providers.docker.network=reverse-proxy
+      - --providers.docker.exposedByDefault=false
+      ## Metrics
+      - --metrics.prometheus=true
+      - --metrics.prometheus.buckets=0.1,0.3,1.2,5.0
+      # Certificates
+      - --certificatesResolvers.le.acme.httpchallenge=true
+      - --certificatesResolvers.le.acme.httpchallenge.entrypoint=http
+      - --certificatesResolvers.le.acme.email={LE_EMAIL}
+      - --certificatesResolvers.le.acme.storage=/letsencrypt/acme.json
+      # Middlewares
+      - --entrypoints.http.http.redirections.entrypoint.to=https
+      - --entrypoints.http.http.redirections.entrypoint.scheme=https
+    restart: unless-stopped
+    ports:
+      - target: 80
+        published: 80
+        mode: host
+      - target: 443
+        published: 443
+        mode: host
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
+    env_file: .env.traefik
+    networks:
+      - reverse-proxy
+    volumes:
+      # Let's Encrypt certs folder
+      - type: volume
+        source: letsencrypt
+        target: /letsencrypt
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+
+networks:
+  reverse-proxy:
+    name: reverse-proxy
+    driver: bridge
+volumes:
+  letsencrypt:

--- a/traefik/sync.sh
+++ b/traefik/sync.sh
@@ -1,0 +1,1 @@
+rsync -a --delete --quiet traefik/docker-compose.yaml /services/traefik/docker-compose.yaml


### PR DESCRIPTION
## Creating docker-compose file for Traefik reverse proxy.
  - Let's Encrypt TLS certificates enabled 
  - HTTP to HTTPS redirection